### PR TITLE
SMBv1 is disabled/ removed since 1709 build

### DIFF
--- a/windows_10_hardening.md
+++ b/windows_10_hardening.md
@@ -7,7 +7,7 @@ The IDs correspond to the finding lists for HardeningKitty [finding_list_0x6d696
 * Use a separate local admin account
 * ID 1708: Use BitLocker with Enhanced PIN
 * Enable Windows Defender
-* ID 1000: Disable SMBv1
+* ID 1000: Disable SMBv1 (only needed for Windows <1709 build)
 	* Check Status: `Get-WindowsOptionalFeature -Online -FeatureName smb1protocol`
 	* Disable: `Disable-WindowsOptionalFeature -Online -FeatureName smb1protocol`
 


### PR DESCRIPTION
see https://docs.microsoft.com/en-us/windows-server/storage/file-server/troubleshoot/smbv1-not-installed-by-default-in-windows

I would even remove the whole part as it's deprecated.