### PR TITLE
Adding Min PIN length policy (1663)

### DIFF
--- a/lists/finding_list_0x6d69636b_machine.csv
+++ b/lists/finding_list_0x6d69636b_machine.csv
@@ -137,6 +137,7 @@ ID,Category,Name,Method,MethodArgument,RegistryPath,RegistryItem,ClassName,Names
 1660,"Administrative Templates: System","Logon: Turn on convenience PIN sign-in",Registry,,HKLM:\Software\Policies\Microsoft\Windows\System,AllowDomainPINLogon,,,,1,0,=,Medium
 1661,"Administrative Templates: System","Logon: Turn off app notifications on the lock screen",Registry,,HKLM:\Software\Policies\Microsoft\Windows\System,DisableLockScreenAppNotifications,,,,0,1,=,Medium
 1662,"Administrative Templates: System","Logon: Do not display network selection UI",Registry,,HKLM:\Software\Policies\Microsoft\Windows\System,DontDisplayNetworkSelectionUI,,,,0,1,=,Medium
+1663,"Administrative Templates: System","Logon: Maximum PIN length",Registry,,HKLM:\Software\Policies\Microsoft\PassportForWork\PINComplexity,MaximumPINLength,,,,4,6,=,Medium
 1670,"Administrative Templates: System","Mitigation Options: Untrusted Font Blocking",Registry,,"HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\MitigationOptions",MitigationOptions_FontBocking,,,,0,1000000000000,=,Medium
 1680,"Administrative Templates: System","OS Policies: Allow Clipboard synchronization across devices",Registry,,HKLM:\SOFTWARE\Policies\Microsoft\Windows\System,AllowCrossDeviceClipboard,,,,1,0,=,Medium
 1685,"Administrative Templates: System","Sleep Settings: Require a password when a computer wakes (plugged in)",Registry,,HKLM:\Software\Policies\Microsoft\Power\PowerSettings\0e796bdb-100d-47d6-a2d5-f7d2daa51f51,ACSettingIndex,,,,0,1,=,Medium


### PR DESCRIPTION
I propose to add this policy with default value 4 and give 6 to the recommended value.

More info about this policy : https://admx.help/?Category=Windows_10_2016&Policy=Microsoft.Policies.MicrosoftPassportForWork::MSPassport_MaximumPINLength