### PR TITLE
Update MpPreference error trigger

### DIFF
--- a/Invoke-HardeningKitty.ps1
+++ b/Invoke-HardeningKitty.ps1
@@ -1468,7 +1468,7 @@
 
                 $Result = Invoke-Expression $ResultCommand
 
-                if($LastExitCode -eq 1) {
+                if($LastExitCode -eq 0) {
                     $ResultText = "Method value modified"
                     $Message = "ID "+$Finding.ID+", "+$Finding.MethodArgument+", " + $ResultText
                     $MessageSeverity = "Passed"


### PR DESCRIPTION
I figured out that this error were caused by a misconfiguration in the powershell script. Those policies use the method “MpPreference”.

For the policy 1802, $ResultMethodArgument is equal to : MAPSReporting, and $ResultRecommendedValue is equal to : 2.
$ResultCommand is finally equal to : Set-MpPreference -MAPSReporting 2
And $Result (The command executed) is equal to :
Invoke-Expression “Set-MpPreference -MAPSReporting 2”

When I try this command on my computer, no error occurres, and the last exit code is ‘0’.
In the code, it prompt an error if the $LastExistCode is something else than 1. So I modified the script by : if($LastExitCode -eq 0) …, and I have no error remaining and the value is applied correctly.
[Proof of concept - 1800 policies.docx](https://github.com/0x6d69636b/windows_hardening/files/7303236/Proof.of.concept.-.1800.policies.docx)

