### PR TITLE
Add Location of Powershell transcription

### DIFF
--- a/lists/finding_list_0x6d69636b_machine.csv
+++ b/lists/finding_list_0x6d69636b_machine.csv
@@ -274,8 +274,9 @@ ID,Category,Name,Method,MethodArgument,RegistryPath,RegistryItem,ClassName,Names
 2100,PowerShell,"Turn on PowerShell Script Block Logging",Registry,,HKLM:\Software\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging,EnableScriptBlockLogging,,,,0,1,=,Medium
 2101,PowerShell,"Turn on PowerShell Script Block Logging (Invocation)",Registry,,HKLM:\Software\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging,EnableScriptBlockInvocationLogging,,,,0,1,=,Low
 2102,PowerShell,"Turn on PowerShell Transcription",Registry,,HKLM:\Software\Policies\Microsoft\Windows\PowerShell\Transcription,EnableTranscripting,,,,0,1,=,Low
-2103,PowerShell,"Disable PowerShell version 2",WindowsOptionalFeature,MicrosoftWindowsPowerShellV2,,,,,,Enabled,Disabled,=,Medium
-2104,PowerShell,"Disable PowerShell version 2 (root)",WindowsOptionalFeature,MicrosoftWindowsPowerShellV2Root,,,,,,Enabled,Disabled,=,Medium
+2103,PowerShell,"Turn on PowerShell Transcription (Location)",Registry,,HKLM:\Software\Policies\Microsoft\Windows\PowerShell\Transcription,OutputDirectory,,,,C:\Users\${env:USERNAME}\Documents\,C:\Users\${env:USERNAME}\AppData\Local,=,Low
+2104,PowerShell,"Disable PowerShell version 2",WindowsOptionalFeature,MicrosoftWindowsPowerShellV2,,,,,,Enabled,Disabled,=,Medium
+2105,PowerShell,"Disable PowerShell version 2 (root)",WindowsOptionalFeature,MicrosoftWindowsPowerShellV2Root,,,,,,Enabled,Disabled,=,Medium
 2200,"MS Security Guide","LSA Protection",Registry,,HKLM:\SYSTEM\CurrentControlSet\Control\Lsa,RunAsPPL,,,,,1,=,Medium
 2201,"MS Security Guide","Lsass.exe audit mode",Registry,,"HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\LSASS.exe",AuditLevel,,,,,8,=,Low
 2202,"MS Security Guide","NetBT NodeType configuration",Registry,,HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters,NodeType,,,,0,2,=,Medium


### PR DESCRIPTION
When powershell transcription is enabled, all logs are saving in Document directory. So, this policy allows to change this directory. 

Also, to add this policy (2103), I have incremented numbers of 2 policies (2103 -> 2104; 2104 -> 2105).