### PR TITLE
Improve backups to remove non existing policies

### DIFF
--- a/HardeningKitty.psm1
+++ b/HardeningKitty.psm1
@@ -1,4 +1,4 @@
-﻿Function Invoke-HardeningKitty {
+Function Invoke-HardeningKitty {
 
     <#
     .SYNOPSIS
@@ -809,7 +809,13 @@
                         }
                     }
                 } Else {
-                    $Result = $Finding.DefaultValue
+                    If ($Backup) {
+                        # If this policy does not exist and the backup mode is enabled, we 
+                        # put "-NODATA-" as result to identify it as non-existing policy
+                        $Result = "-NODATA-"
+                    } Else {
+                        $Result = $Finding.DefaultValue
+                    }
                 }
             }
 
@@ -879,7 +885,13 @@
                         $Result = $Finding.DefaultValue
                     }
                 } Else {
-                    $Result = $Finding.DefaultValue
+                    If ($Backup) {
+                        # If this policy does not exist and the backup mode is enabled, we 
+                        # put "-NODATA-" as result to identify it as non-existing policy
+                        $Result = "-NODATA-"
+                    } Else {
+                        $Result = $Finding.DefaultValue
+                    }
                 }
             }
 

--- a/HardeningKitty.psm1
+++ b/HardeningKitty.psm1
@@ -577,7 +577,7 @@
     #
     # Start Main
     #
-    $HardeningKittyVersion = "0.9.1-1676202455"
+    $HardeningKittyVersion = "0.9.1-1677054190"
 
     #
     # Log, report and backup file

--- a/HardeningKitty.psm1
+++ b/HardeningKitty.psm1
@@ -1,4 +1,4 @@
-Function Invoke-HardeningKitty {
+﻿Function Invoke-HardeningKitty {
 
     <#
     .SYNOPSIS
@@ -801,7 +801,7 @@ Function Invoke-HardeningKitty {
                         }
                     } catch {
                         If ($Backup) {
-                            # If backup mode is enabled, with consider that this backup does not exists
+                            # If an error occurs and the backup mode is enabled, we consider that this policy does not exist
                             # and put "-NODATA-" as result to identify it as non-existing policy
                             $Result = "-NODATA-"
                         } Else {
@@ -1853,7 +1853,7 @@ Function Invoke-HardeningKitty {
                     $keyExists = $true;
                     try {
                         # This key exists
-                        Get-ItemPropertyValue -Path $Finding.RegistryPath -Name $Finding.RegistryItem
+                        $Result = Get-ItemPropertyValue -Path $Finding.RegistryPath -Name $Finding.RegistryItem
                     } catch {
                         # This key does not exist
                         $keyExists = $false;

--- a/HardeningKitty.psm1
+++ b/HardeningKitty.psm1
@@ -1,4 +1,4 @@
-Function Invoke-HardeningKitty {
+﻿Function Invoke-HardeningKitty {
 
     <#
     .SYNOPSIS
@@ -1800,8 +1800,8 @@ Function Invoke-HardeningKitty {
                     $ResultListCounter = 0
                     If ($ResultList | Where-Object { $_ -like "*" + $Finding.RegistryItem + "*" }) {
                         $ResultList.PSObject.Properties | ForEach-Object {
-                            If ( $_.Value -eq $Finding.RegistryItem ) {
-                                $Finding.RegistryItem = $_.Value.Name
+                            If ( $_.Value -eq $Finding.RecommendedValue ) {
+                                $Finding.RegistryItem = $_.Name
                                 Continue
                             }
                         }

--- a/HardeningKitty.psm1
+++ b/HardeningKitty.psm1
@@ -1,4 +1,4 @@
-﻿Function Invoke-HardeningKitty {
+Function Invoke-HardeningKitty {
 
     <#
     .SYNOPSIS
@@ -800,7 +800,13 @@
                             $Result = $Result -join ";"
                         }
                     } catch {
-                        $Result = $Finding.DefaultValue
+                        If ($Backup) {
+                            # If backup mode is enabled, with consider that this backup does not exists
+                            # and put "-NODATA-" as result to identify it as non-existing policy
+                            $Result = "-NODATA-"
+                        } Else {
+                            $Result = $Finding.DefaultValue
+                        }
                     }
                 } Else {
                     $Result = $Finding.DefaultValue
@@ -866,7 +872,7 @@
                         If ($ResultList | Where-Object { $_ -like "*" + $Finding.RegistryItem + "*" }) {
                             $Result = $Finding.RegistryItem
                         } Else {
-                            $Result = "Not found"
+                            $Result = "-NODATA-"
                         }
 
                     } catch {


### PR DESCRIPTION
Hi Michael !

Because a good backup allows to "back" to an initial state, it was not relevant to keep policies that did not exist during a backup. 
To do this, the script will store "-NODATA-" value when a policies does not exist during a backup, and when hardening is applying with this backup as a FileFindingList, the script will remove policies keys with "-NODATA-".