### PR TITLE
Add NullSessionShares to Multistring Registry entries

### DIFF
--- a/HardeningKitty.psm1
+++ b/HardeningKitty.psm1
@@ -849,7 +849,7 @@
                     try {
                         $Result = Get-ItemPropertyValue -Path $Finding.RegistryPath -Name $Finding.RegistryItem
                         # Join the result with ";" character if result is an array
-                        if ($Result -is [system.array] -and ($Finding.RegistryItem -eq "Machine" -Or $Finding.RegistryItem -eq "EccCurves" -Or $Finding.RegistryItem -eq "NullSessionPipes")){
+                        if ($Result -is [system.array] -and ($Finding.RegistryItem -eq "Machine" -Or $Finding.RegistryItem -eq "EccCurves" -Or $Finding.RegistryItem -eq "NullSessionPipes" -Or $Finding.RegistryItem -eq "NullSessionShares")){
                             $Result = $Result -join ";"
                         }
                     } catch {
@@ -1800,7 +1800,7 @@
                 #
                 If ($Finding.RegistryItem -eq "MitigationOptions_FontBocking" -Or $Finding.RegistryItem -eq "Retention" -Or $Finding.RegistryItem -eq "AllocateDASD" -Or $Finding.RegistryItem -eq "ScRemoveOption" -Or $Finding.RegistryItem -eq "AutoAdminLogon") {
                     $RegType = "String"
-                } ElseIf ($Finding.RegistryItem -eq "Machine" -Or $Finding.RegistryItem -eq "EccCurves" -Or $Finding.RegistryItem -eq "NullSessionPipes") {
+                } ElseIf ($Finding.RegistryItem -eq "Machine" -Or $Finding.RegistryItem -eq "EccCurves" -Or $Finding.RegistryItem -eq "NullSessionPipes" -Or $Finding.RegistryItem -eq "NullSessionShares") {
                     $RegType = "MultiString"
                     $Finding.RecommendedValue = $Finding.RecommendedValue -split ";"
                 } ElseIf ($Finding.RecommendedValue -match "^\d+$") {


### PR DESCRIPTION
When the `NullSessionShares` Registry Key in `HKLM:\System\CurrentControlSet\Services\LanManServer\Parameters` is set as a normal String it breaks the Powershell `Get-SMBServerConfiguration` cmdlet with a "data of this type is not supported" Error message.

This PR just adds NullSessionShares to the list of Multi Strings.

NullSessionShares is String:
![FB9U0artIr](https://github.com/0x6d69636b/windows_hardening/assets/25851990/1d67802f-03fb-404d-8fe0-6622ed7e9e27)


NullSessionShares is Multi String:
![mstsc_jnr5jA9ybi](https://github.com/0x6d69636b/windows_hardening/assets/25851990/efa86fc6-30ea-494a-a185-ed5c2b40cc3d)
