### PR TITLE
Update Firewall Rule if it already exists

### DIFF
--- a/HardeningKitty.psm1
+++ b/HardeningKitty.psm1
@@ -3059,7 +3059,8 @@
                     }
                 } Else {
                     # Excellent
-                    $ResultText = "Rule already exists"
+                    $ResultText = "Rule already exists, setting Recommended Value"
+                    Set-NetFirewallRule -DisplayName $FwDisplayName -Enabled $Finding.RecommendedValue
                     $Message = "ID " + $Finding.ID + ", " + $Finding.Name + ", " + $ResultText
                     $MessageSeverity = "Passed"
                     $TestResult = "Passed"


### PR DESCRIPTION
This PR adds a Line to the Firewall Rule check that just enables a Firewall Rule if it already exists.

I use HardeningKitty to enable some predefined Firewall Rules in Windows (like allowing Remotedesktop) that are disabled by default.
With this change, if the Rule exists, it also sets the RecommendedValue for it.